### PR TITLE
Ported pipeline to work on 64 bit Debian 9

### DIFF
--- a/T_plugin.py
+++ b/T_plugin.py
@@ -40,19 +40,22 @@ def save_results(result_filename):
 	IJ.saveAs("Results", result_filename)
 	return None
 
-name = sys.argv[0]
-folder = name[:name.rfind('\\')].replace('\\','/')
-print(folder)
-tree = et.parse(folder + '/info.xml')
-out = tree.findtext('csv')
-image_foldername = tree.findtext('images')
-roi_archive = tree.findtext('ROI_archive')
-print(out,image_foldername,roi_archive)
+def main():
+	name = sys.argv[0]
+	folder = name[:name.rfind('/')]
+	print(folder)
+	tree = et.parse(folder + '/info.xml')
+	out = tree.findtext('csv')
+	image_foldername = tree.findtext('images')
+	roi_archive = tree.findtext('ROI_archive')
+	print(out,image_foldername,roi_archive)
+	
+	stack = folder_to_stack(image_foldername)
+	stack = register(stack)
+	stack = median(stack)
+	rm = get_rois(roi_archive)
+	measure_stack(stack,stack.getImageStackSize(),rm)
+	save_results(out)
+	print("Done")
 
-stack = folder_to_stack(image_foldername)
-stack = register(stack)
-stack = median(stack)
-rm = get_rois(roi_archive)
-measure_stack(stack,stack.getImageStackSize(),rm)
-save_results(out)
-print("Done")
+main()

--- a/info.xml
+++ b/info.xml
@@ -1,6 +1,6 @@
 <info>
-	<csv>C:/Users/Tomas/Documents/Luciferase/Tomas_Pipeline_Measurements.csv</csv>
-	<images>C:/Users/Tomas/Documents/Luciferase/images/data/</images>
-	<ROI_archive>C:/Users/Tomas/Documents/Luciferase/code/RoiSet.zip</ROI_archive>
-	<imagej>C:/Users/Tomas/Documents/Fiji.app/</imagej>
+	<csv>/home/tomas/Documents/Luciferase/Tomas_Pipeline_Measurements.csv</csv>
+	<images>/home/tomas/Documents/Luciferase/images/data/</images>
+	<ROI_archive>/home/tomas/Documents/Luciferase/code/RoiSet.zip</ROI_archive>
+	<imagej>/home/tomas/Fiji.app/</imagej>
 </info>

--- a/main.py
+++ b/main.py
@@ -6,6 +6,6 @@ from matplotlib import pyplot
 
 info = ElementTree.parse('info.xml')
 imagejfolder = info.findtext('imagej')
-sub.run([imagejfolder+'ImageJ-win64.exe','--run',abspath('T_plugin.py')])
+sub.run([imagejfolder+'ImageJ-linux64','--run',abspath('T_plugin.py')])
 main()
 pyplot.show()


### PR DESCRIPTION
In this I converted the pipeline to work on Debian 9.
To install the pipeline in Debian:
* Install ImageJ
* Install Spyder3
* download the program
* create your RoiSet.zip file
* edit groups.xml and info.xml until they match what you have on your system.
* install pip3 (if you have not already)
* install numpy, pandas, and matplotlib using pip3

To use the program:

- Open main.py with Spyder3
- Click the Run button (the green triangle in the upper menu)
- At this point, the program runs an ImageJ plugin. let it run, then wait about a minute after you think it is finished

- Then close ImageJ, and click the "no" button on the pop-up about whether to save modified images.
- Answer the prompt about whether to use the medians in the terminal section in Spyder3.
    - if you type yes, it will use medians
    - if you type no, it will use means

After a few minutes (depending on how many images you have and how large they are) the graph
will appear in the IPython terminal in Spyder3
